### PR TITLE
src/bandwidthd.h: fix build with gcc 10

### DIFF
--- a/src/bandwidthd.h
+++ b/src/bandwidthd.h
@@ -134,7 +134,7 @@ struct SubnetData
 {
   uint32_t ip;
   uint32_t mask;
-} SubnetTable[SUBNET_NUM];
+};
 
 struct Statistics
 {
@@ -157,7 +157,7 @@ struct IPData
   uint32_t ip;			// Host byte order
   struct Statistics Send;
   struct Statistics Receive;
-} IpTable[IP_NUM];
+};
 
 struct SummaryData
 {

--- a/src/graph.c
+++ b/src/graph.c
@@ -18,6 +18,7 @@
 #include <resolv.h>
 #endif
 
+extern struct SubnetData SubnetTable[SUBNET_NUM];
 extern unsigned int SubnetCount;
 extern struct config config;
 


### PR DESCRIPTION
Remove SubnetTable[SUBNET_NUM] and IpTable[IP_NUM] from bandwidthd.h as they are already in bandwidthd.c otherwise the build with gcc 10 will fail on:

```
/home/buildroot/autobuild/instance-2/output-1/host/bin/arm-buildroot-linux-gnueabihf-gcc  -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os     -o bandwidthd bandwidthd.o graph.o extensions.o sqlight.o parser.o lexer.o pgsql.o  -lpcap -lgd -lm -lresolv  -L/home/buildroot/autobuild/instance-2/output-1/host/bin/../arm-buildroot-linux-gnueabihf/sysroot/usr/lib -lpng16 -lz  -L/home/buildroot/autobuild/instance-2/output-1/host/arm-buildroot-linux-gnueabihf/sysroot/usr/bin/../../../../arm-buildroot-linux-gnueabihf/sysroot/usr/lib/.libs -lnl-genl-3 -lnl-3
/home/buildroot/autobuild/instance-2/output-1/host/lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: graph.o:(.bss+0x4b0): multiple definition of `IpTable'; bandwidthd.o:(.bss+0x3e0): first defined here
/home/buildroot/autobuild/instance-2/output-1/host/lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: graph.o:(.bss+0x18c): multiple definition of `SubnetTable'; bandwidthd.o:(.bss+0x88): first defined here

```

Fixes:
 - http://autobuild.buildroot.org/results/6308c8ee38b6017215038d47c009b238113bd36f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>