### PR TITLE
src/parser.y: fix build with gcc >= 14

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -11,6 +11,7 @@
 #include <arpa/inet.h>
 #include "bandwidthd.h"
 
+extern int yylex (void);
 extern unsigned int SubnetCount;
 extern struct SubnetData SubnetTable[];
 extern struct config config;


### PR DESCRIPTION
Fix the following build failure with gcc >= 14:

```
parser.c: In function 'yyparse':
parser.c:1196:16: error: implicit declaration of function 'yylex' [-Wimplicit-function-declaration]
 1196 |       yychar = yylex ();
      |                ^~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/33364071de4e5e51a2ac2337b82d145f71e0e64a